### PR TITLE
fix(ci): use shared docker network and unblock dependency-bump releases

### DIFF
--- a/.claude/commands/branch.md
+++ b/.claude/commands/branch.md
@@ -1,0 +1,19 @@
+---
+description: Create a new branch off the current one and sync it with main early to avoid conflicts later
+argument-hint: [branch-name]
+---
+
+Create a new branch that continues from the current branch's state, and merge the latest `main` into it right away — catching and resolving any conflicts now instead of later at PR time.
+
+Steps:
+1. Determine the branch name:
+   - If `$ARGUMENTS` was given, use it as-is (assume the user chose it deliberately).
+   - Otherwise infer one from the pending/recent changes: `<type>/<short-kebab-slug>`, using the same Conventional Commit types as `/commit` (`feat|fix|docs|chore|refactor|perf|test|ci|style|build`).
+2. If there are uncommitted changes, stash them first with a descriptive message (`git stash push -m "..."`) so the branch switch is clean. Don't use a blanket stash if only some of the working tree changes are meant to travel with this branch — stash specific paths (`git stash push -- <paths>`) and leave the rest untouched.
+3. `git fetch origin` to get the latest `main`.
+4. `git checkout -b <branch-name>` from the current HEAD (not from `origin/main` — this branches off what you already have).
+5. `git merge origin/main`. If there are conflicts, resolve them properly (understand both sides of each hunk — don't blindly pick one) rather than punting back to the user unless a conflict requires a decision only they can make.
+6. If anything was stashed in step 2, `git stash pop` and resolve any conflicts there too.
+7. Do not push — that's `/push`'s job.
+
+End with a one-line summary: the new branch name, whether it needed conflict resolution (and what kind), and confirmation it's ready to keep working on.

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,0 +1,17 @@
+---
+description: Commit the current changes with a Conventional Commits message in English
+---
+
+Commit the pending changes in this repository.
+
+Steps:
+1. Run `git status` and `git diff` (staged and unstaged) to see everything that would be committed. Never use `git add -A` or `git add .` — stage specific files by name so nothing unintended (secrets, stray local files) gets swept in.
+2. If there is nothing to commit, say so and stop — do not create an empty commit.
+3. Decide yourself how many commits this needs and which files go in each — don't default to one giant commit just because everything is uncommitted at once. Group by logical concern: if unrelated things were touched (e.g. a CI fix and an unrelated source fix, or a docs update alongside a bug fix), split them into separate commits so each one tells a single story. Only ask the user if it's genuinely ambiguous which concern a file belongs to.
+4. Write each commit message in **English**, following Conventional Commits: `<type>[optional scope]: <description>`.
+   - Allowed types: `feat|fix|docs|chore|refactor|perf|test|ci|style|build` (this repo's `pr-validation` workflow enforces this same set on PR titles, max 100 characters for the description).
+   - Lead with why the change matters, not a restatement of the diff.
+5. Do not push. This command only commits.
+6. Never use `--no-verify` or `--amend` unless the user explicitly asks.
+
+End with a one-line summary of what was committed — list each commit made (or say there was nothing to do).

--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,46 @@
+---
+description: Commit/push if needed, then open a GitHub PR using this repo's template, assigned to the user with the right labels
+---
+
+Open a pull request for the current branch against `main`.
+
+This shares the same "current state" model as `/push` — keep both consistent if you ever change one:
+
+| Current state | What `/pr` does |
+| --- | --- |
+| On `main` | Create a feature branch first (`/branch`'s logic), then treat it as a fresh branch with no PR (continue below). |
+| On a feature branch, no PR open for it yet | Commit if needed, push, then create the PR. |
+| On a feature branch that already has an open PR | Commit if needed, push (landing new commits on that PR) — then **stop and report that PR's URL**. Never create a second branch or a duplicate PR just because you ran `/pr` again. |
+
+Steps:
+1. If the current branch is `main`, follow `/branch`'s logic to create a suitably named feature branch first — never open a PR from `main` itself. Otherwise stay on the current branch.
+2. Run `git status` and `git diff` to see pending changes, and check whether the branch has unpushed commits.
+3. If there are uncommitted changes, commit them first following `/commit`'s rules: stage specific files by name (never `-A`/`.`), split unrelated changes into separate commits, English Conventional Commit messages.
+4. Push the branch if it isn't already up to date with its remote (add `-u origin <branch>` if it has no upstream yet). Never force-push.
+5. Check with `gh pr list --head <branch>` whether a PR already exists for this branch:
+   - If one exists, the commit+push above already updated it — report its URL and stop here. Do not create a new branch or a second PR.
+   - Otherwise, continue to create one below.
+6. Review the full commit history that will go into the PR (`git log origin/main..HEAD`), not just the latest commit, to write an accurate title and body.
+7. **Title** (English): Conventional Commits format — `<type>[optional scope]: <description>`, type one of `feat|fix|docs|chore|refactor|perf|test|ci|style|build`, description max 100 characters. This repo's `pr-validation` workflow (`wf-pr-validation.yml`) enforces this exact pattern and will fail the check otherwise.
+8. **Body** (English): use `.github/pull_request_template.md` as the structure — don't skip sections, and don't leave every checkbox unchecked as a lazy default. For each item, actually verify it before checking it:
+   - **Type of change**: check the box(es) matching the commit type(s) actually used.
+   - **Checklist**: read `CONTRIBUTING.md` and `docs/STYLEGUIDE.md` if unsure, then check each item only if genuinely true for this change (e.g. don't check "tests pass" without having actually run them, don't check "documentation updated" without having checked whether any doc references the thing being changed — `grep` for the changed variable/function names across `README.md` and `docs/` first). Leave boxes unchecked (with a short inline note why) when an item doesn't apply rather than checking it dishonestly.
+   - **Additional Notes**: call out anything a reviewer must do before merging (e.g. a repo variable that needs to be set) and any known limitation (e.g. tests that don't actually run in CI).
+9. **Assignee**: default to `@me` (the authenticated user) unless the user says otherwise for this PR.
+10. **Labels**: pick from the repo's actual labels (`gh label list`) based on what the PR does — don't invent label names. If nothing fits well, leave unlabeled rather than forcing one.
+11. Create the PR:
+    ```
+    gh pr create --title "..." --body "$(cat <<'EOF'
+    ...
+    EOF
+    )" --assignee @me --label <name> [--label <name> ...]
+    ```
+    **Known gh CLI bug in this repo**: `gh pr create`/`gh pr edit` can fail with `GraphQL: Projects (classic) is being deprecated ... (repository.pullRequest.projectCards)` even though the mutation itself (assignee/label/body) is unrelated to Projects. If that happens:
+    - Retry `gh pr create` with just `--title`/`--body` (no assignee/label) to get the PR created.
+    - Then set assignee/labels/body via the REST API instead of `gh pr edit`, e.g.:
+      ```
+      echo '{"assignees":["<login>"]}' | gh api -X POST repos/<owner>/<repo>/issues/<n>/assignees --input -
+      echo '{"labels":["<label>"]}'    | gh api -X POST repos/<owner>/<repo>/issues/<n>/labels --input -
+      gh api -X PATCH repos/<owner>/<repo>/pulls/<n> --input <json-file-with-body-field>
+      ```
+12. Report the PR URL when done.

--- a/.claude/commands/push.md
+++ b/.claude/commands/push.md
@@ -1,0 +1,22 @@
+---
+description: Commit any pending changes (Conventional Commits, English) and push — creating a proper branch first if currently on main
+---
+
+Push the current work to its remote in a single push.
+
+This shares the same "current state" model as `/pr` — keep both consistent if you ever change one:
+
+| Current state | What `/push` does |
+| --- | --- |
+| On `main` | Create a feature branch first (`/branch`'s logic), then push that. |
+| On a feature branch, no PR open for it yet | Commit if needed, push. Nothing else — no PR gets created here. |
+| On a feature branch that already has an open PR | Commit if needed, push. This lands the new commits on that same PR automatically — do **not** create a new branch just because a PR already exists. |
+
+Steps:
+1. Check the current branch. If it's `main` (or any default/protected branch), follow `/branch`'s logic to create a suitably named feature branch first (infer the name from the pending changes if not obvious), then continue the remaining steps on that new branch. Otherwise, stay on the current branch regardless of whether it already has an open PR — never create a new branch just to push more commits to an existing PR.
+2. If there are uncommitted changes, commit them first following `/commit`'s rules: stage specific files (never `-A`/`.`), split unrelated changes into separate commits, write messages in English as Conventional Commits (`feat|fix|docs|chore|refactor|perf|test|ci|style|build`, max 100 char description — same set this repo's `pr-validation` workflow checks on PR titles).
+3. Check for commits ahead of the remote (`git rev-list @{u}..HEAD --count`, or if there's no upstream yet, everything on the branch is unpushed).
+4. If there is nothing to commit and nothing unpushed, say so and stop — do not push an empty no-op.
+5. Push everything in **one** `git push` (add `-u origin <branch>` if the branch has no upstream yet) — don't push after each individual commit if `/commit` created several; one push covers all of them. Never force-push unless the user explicitly asks.
+
+End with a one-line summary: what was committed (if anything), whether a new branch was created, and that the push succeeded, with the branch name. If the branch already has an open PR, mention its URL too (the push just updated it).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(deps)"
+      prefix: "fix(deps)"
     labels:
       - "dependencies"
 
@@ -14,6 +14,6 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(docker)"
+      prefix: "fix(docker)"
     labels:
       - "dependencies"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,27 +4,29 @@
 
 Please include a summary of the changes and the related issue(s). Be sure to explain **why** this change is necessary and **what** it solves.
 
-Fixes #(issue_number)
+Fixes #(issue_number) (remove this line if not applicable)
 
 ## Type of change
 
-Please mark the relevant options:
+Please mark the relevant options. These match the [Conventional Commits](../blob/main/docs/STYLEGUIDE.md#conventional-commits) types enforced on the PR title:
 
-- [ ] Bug fix (non-breaking change that fixes an issue)
-- [ ] New feature (non-breaking change that adds functionality)
-- [ ] Improvement
-- [ ] Performance optimization
-- [ ] Refactor update
-- [ ] Documentation update
-- [ ] Security fix
-- [ ] Test update
-- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] `feat`: New feature (non-breaking change that adds functionality)
+- [ ] `fix`: Bug fix (non-breaking change that fixes an issue)
+- [ ] `docs`: Documentation-only change
+- [ ] `style`: Formatting/lint change with no logic change
+- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
+- [ ] `perf`: Performance improvement
+- [ ] `test`: Adding or updating tests
+- [ ] `ci`: Changes to CI/CD configuration or workflows
+- [ ] `chore`: Maintenance tasks (e.g. dependency updates)
+- [ ] `build`: Changes to the build system or dependencies
+- [ ] Breaking change (any of the above that would cause existing functionality to not work as expected)
 - [ ] Other (please describe):
 
 ## Checklist
 
 - [ ] I have read the [**CONTRIBUTING**](../blob/main/CONTRIBUTING.md) guidelines
-- [ ] The code follows the project's coding standards and best practices (see [**STYLEGUIDE**](../blob/main/docs/styleguide.md))
+- [ ] The code follows the project's coding standards and best practices (see [**STYLEGUIDE**](../blob/main/docs/STYLEGUIDE.md))
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have updated the [**README**](../blob/main/README.md) or documentation, if necessary
 - [ ] I have added relevant tests that prove my fix is effective or that my feature works

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -12,6 +12,10 @@ permissions:
   actions: write
   security-events: write
 
+concurrency:
+  group: straperr-deploy
+  cancel-in-progress: false
+
 defaults:
   run:
     shell: bash
@@ -104,7 +108,7 @@ jobs:
             "healthcheck_url": "${{ vars.DOCKER_HEALTHCHECK_URL }}",
             "memory_limit": "${{ vars.DOCKER_MEMORY_LIMIT }}",
             "memory_reservation": "${{ vars.DOCKER_MEMORY_RESERVATION }}",
-            "extra_networks": ["${{ vars.DOCKER_NETWORK_STRAPERR }}"],
+            "network": "${{ vars.DOCKER_NETWORK }}",
             "env_vars": {
               "PUID": "1000",
               "PGID": "1000",

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ permissions:
   packages: read
   actions: write
 
+concurrency:
+  group: straperr-deploy
+  cancel-in-progress: false
+
 defaults:
   run:
     shell: bash
@@ -36,7 +40,7 @@ jobs:
             "healthcheck_url": "${{ vars.DOCKER_HEALTHCHECK_URL }}",
             "memory_limit": "${{ vars.DOCKER_MEMORY_LIMIT }}",
             "memory_reservation": "${{ vars.DOCKER_MEMORY_RESERVATION }}",
-            "extra_networks": ["${{ vars.DOCKER_NETWORK_STRAPERR }}"],
+            "network": "${{ vars.DOCKER_NETWORK }}",
             "env_vars": {
               "PUID": "1000",
               "PGID": "1000",

--- a/.github/workflows/remove-deploy.yml
+++ b/.github/workflows/remove-deploy.yml
@@ -33,14 +33,6 @@ jobs:
             docker rm -f "${{ env.REPO_NAME }}"
           fi
 
-      - name: Remove straperr docker network
-        env:
-          DOCKER_NETWORK_STRAPERR: ${{ secrets.DOCKER_NETWORK_STRAPERR }}
-        run: |
-          if [ "$(docker network ls -q -f name=\"${{ env.DOCKER_NETWORK_STRAPERR }}\")" ]; then
-            docker network rm "${{ env.DOCKER_NETWORK_STRAPERR }}"
-          fi
-
       - name: Remove old docker images
         env:
           GITHUB_REPOSITORY: ${{ github.repository }}

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ To properly configure the application, you need to set the following variables i
 Also, you need to set the environment variables for the Docker service
 (as GitHub Actions repository variables, used by the deploy workflows):
 
-- **DOCKER_NETWORK_STRAPERR**: Docker network the deployed container joins.
+- **DOCKER_NETWORK**: Existing Docker network the deployed container joins.
 - **DOCKER_HEALTHCHECK_URL**: Healthcheck URL for the service application (`/status`).
 - **DOCKER_MEMORY_LIMIT**: Memory limit for the Docker service. The container
   runs a headless Chromium for the HD-Olimpo login, so this needs real

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -20,9 +20,9 @@ This file contains the necessary configurations for the integration and deployme
 
 ### Docker Configuration Variables
 
-- **`DOCKER_NETWORK_STRAPERR`**:
-  - **Description**: The name of the Docker network the deployed container joins.
-  - **Example**: `straperr_network`
+- **`DOCKER_NETWORK`**:
+  - **Description**: The name of the existing Docker network the deployed container joins.
+  - **Example**: `shared_network`
 
 - **`DOCKER_HEALTHCHECK_URL`**:
   - **Description**: The URL to use for the Docker healthcheck.

--- a/src/main.py
+++ b/src/main.py
@@ -9,7 +9,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
 
-# ── Credenciales HD-Olimpo ────────────────────────────────────────────────────
+# ── Credenciales HD-Olimpo ───────────────────────────────────────────────────
 HDOLIMPO_BASE_URL = "https://hd-olimpo.club"
 HDOLIMPO_USERNAME = os.environ.get('HDOLIMPO_USERNAME')
 HDOLIMPO_PASSWORD = os.environ.get('HDOLIMPO_PASSWORD')
@@ -41,7 +41,7 @@ ARR_INSTANCES: dict[str, dict] = {
 app = Flask(__name__)
 
 
-# ── Logger ────────────────────────────────────────────────────────────────────
+# ── Logger ───────────────────────────────────────────────────────────────────
 def setup_logger(name: str = 'straperr') -> logging.Logger:
     logger = logging.getLogger(name)
     if not logger.handlers:
@@ -58,7 +58,7 @@ def setup_logger(name: str = 'straperr') -> logging.Logger:
 logger = setup_logger()
 
 
-# ── Helpers de instancia ──────────────────────────────────────────────────────
+# ── Helpers de instancia ─────────────────────────────────────────────────────
 def get_arr_instance(name: str) -> dict:
     """Devuelve el config dict de la instancia o lanza ValueError."""
     instance = ARR_INSTANCES.get(name)
@@ -71,7 +71,7 @@ def arr_headers(instance: dict) -> dict:
     return {'X-Api-Key': instance['api_key']}
 
 
-# ── *Arr API ──────────────────────────────────────────────────────────────────
+# ── *Arr API ─────────────────────────────────────────────────────────────────
 def get_manual_import(download_id: str, instance_name: str) -> list | None:
     try:
         instance = get_arr_instance(instance_name)
@@ -88,7 +88,9 @@ def get_manual_import(download_id: str, instance_name: str) -> list | None:
     if response.status_code == 200:
         return response.json()
 
-    logger.error(f"GET /manualimport error {response.status_code}: {response.text}")
+    logger.error(
+        f"GET /manualimport error {response.status_code}: {response.text}"
+    )
     return None
 
 
@@ -97,11 +99,15 @@ def get_languages_for_download(download_id: str, instance_name: str) -> list:
     import_records = get_manual_import(download_id, instance_name)
     if import_records and import_records[0].get("languages"):
         return import_records[0]["languages"]
-    logger.warning("No se encontraron idiomas en la respuesta de manualimport.")
+    logger.warning(
+        "No se encontraron idiomas en la respuesta de manualimport."
+    )
     return []
 
 
-def post_manual_import(record: dict, languages: list, instance_name: str) -> None:
+def post_manual_import(
+    record: dict, languages: list, instance_name: str
+) -> None:
     try:
         instance = get_arr_instance(instance_name)
     except ValueError as e:
@@ -133,7 +139,9 @@ def post_manual_import(record: dict, languages: list, instance_name: str) -> Non
 
     logger.info(f"POST ManualImport payload: {payload}")
 
-    response = requests.post(f"{instance['api_url']}/command", headers=headers, json=payload)
+    response = requests.post(
+        f"{instance['api_url']}/command", headers=headers, json=payload
+    )
     if response.status_code == 201:
         logger.info(f"ManualImport OK → {record['name']!r}")
     else:
@@ -143,7 +151,9 @@ def post_manual_import(record: dict, languages: list, instance_name: str) -> Non
         )
 
 
-def delete_queue_items_by_download_id(download_id: str, instance_name: str) -> None:
+def delete_queue_items_by_download_id(
+    download_id: str, instance_name: str
+) -> None:
     try:
         instance = get_arr_instance(instance_name)
     except ValueError as e:
@@ -157,7 +167,9 @@ def delete_queue_items_by_download_id(download_id: str, instance_name: str) -> N
         response = requests.get(queue_url, headers=headers)
         response.raise_for_status()
         queue = response.json()
-        records = queue.get('records', queue) if isinstance(queue, dict) else queue
+        records = (
+            queue.get('records', queue) if isinstance(queue, dict) else queue
+        )
 
         for item in records:
             if item.get('downloadId') != download_id:
@@ -170,7 +182,9 @@ def delete_queue_items_by_download_id(download_id: str, instance_name: str) -> N
             )
             delete_response = requests.delete(delete_url, headers=headers)
             if delete_response.status_code == 200:
-                logger.info(f"Queue item {queue_id} eliminado de {instance_name}")
+                logger.info(
+                    f"Queue item {queue_id} eliminado de {instance_name}"
+                )
             else:
                 logger.error(
                     f"No se pudo eliminar queue item {queue_id}: "
@@ -180,7 +194,7 @@ def delete_queue_items_by_download_id(download_id: str, instance_name: str) -> N
         logger.error(f"Error eliminando items de la cola: {e}")
 
 
-# ── HD-Olimpo: thanks con Chromium local ──────────────────────────────────────
+# ── HD-Olimpo: thanks con Chromium local ─────────────────────────────────────
 def build_chrome_driver() -> webdriver.Chrome:
     """
     Configura un Chromium headless instalado en el propio contenedor (paquetes
@@ -188,14 +202,18 @@ def build_chrome_driver() -> webdriver.Chrome:
     contenedor Selenium Grid externo.
     """
     options = Options()
-    options.binary_location = os.environ.get('CHROME_BIN', '/usr/bin/chromium-browser')
+    options.binary_location = os.environ.get(
+        'CHROME_BIN', '/usr/bin/chromium-browser'
+    )
     options.add_argument('--headless=new')
     options.add_argument('--no-sandbox')
     options.add_argument('--disable-dev-shm-usage')
     options.add_argument('--disable-gpu')
 
     service = Service(
-        executable_path=os.environ.get('CHROMEDRIVER_PATH', '/usr/bin/chromedriver')
+        executable_path=os.environ.get(
+            'CHROMEDRIVER_PATH', '/usr/bin/chromedriver'
+        )
     )
     return webdriver.Chrome(service=service, options=options)
 
@@ -228,7 +246,7 @@ def hdolimpo_thanks(
         driver = build_chrome_driver()
         driver.set_page_load_timeout(30)
 
-        # ── 1. Login ──────────────────────────────────────────────────────────
+        # ── 1. Login ─────────────────────────────────────────────────────────
         driver.get(f"{HDOLIMPO_BASE_URL}/login")
         time.sleep(2)
 
@@ -245,7 +263,10 @@ def hdolimpo_thanks(
         time.sleep(3)
 
         if "Iniciar sesión" in driver.page_source:
-            log.error("Login fallido en HD-Olimpo (credenciales incorrectas o bloqueo anti-bot).")
+            log.error(
+                "Login fallido en HD-Olimpo "
+                "(credenciales incorrectas o bloqueo anti-bot)."
+            )
             return False
 
         log.info("Login exitoso en HD-Olimpo.")
@@ -266,7 +287,9 @@ def hdolimpo_thanks(
 
         try:
             torrent_list = driver.find_element(By.ID, "torrent-list-table")
-            result_links = torrent_list.find_elements(By.XPATH, ".//tbody/tr/td/a")
+            result_links = torrent_list.find_elements(
+                By.XPATH, ".//tbody/tr/td/a"
+            )
 
             result_url = None
             for link in result_links:
@@ -312,7 +335,7 @@ def hdolimpo_thanks(
             driver.quit()
 
 
-# ── Utilidades ────────────────────────────────────────────────────────────────
+# ── Utilidades ───────────────────────────────────────────────────────────────
 def clean_release_title(title: str) -> str:
     pattern = r'\b(MULTi|SPANiSH|Eng)\b\s*|\bENGLiSH\b'
 
@@ -322,7 +345,7 @@ def clean_release_title(title: str) -> str:
     return re.sub(pattern, replace, title, flags=re.IGNORECASE).strip()
 
 
-# ── Webhook event handlers ────────────────────────────────────────────────────
+# ── Webhook event handlers ───────────────────────────────────────────────────
 def handle_test(data: dict, log: logging.Logger):
     instance_name = data.get('instanceName', 'straperr')
     log.info(f"Test de conexión desde {instance_name}")
@@ -340,7 +363,9 @@ def handle_grab(data: dict, log: logging.Logger):
 
     clean_title = clean_release_title(release_title)
     log.info(f"Grabando {clean_title!r} desde {indexer}.")
-    hdolimpo_thanks(HDOLIMPO_USERNAME, HDOLIMPO_PASSWORD, clean_title, instance_name)
+    hdolimpo_thanks(
+        HDOLIMPO_USERNAME, HDOLIMPO_PASSWORD, clean_title, instance_name
+    )
     return jsonify({
         "status": "success",
         "message": f"{title!r} desde {indexer} grabado correctamente."
@@ -352,7 +377,10 @@ def handle_download(data: dict, log: logging.Logger):
     release_title = data.get('release', {}).get('releaseTitle', 'Unknown')
     indexer = data.get('release', {}).get('indexer', 'Unknown')
 
-    log.info(f"Descarga completada: {clean_release_title(release_title)!r} desde {indexer}.")
+    log.info(
+        f"Descarga completada: {clean_release_title(release_title)!r} "
+        f"desde {indexer}."
+    )
     return jsonify({
         "status": "success",
         "message": f"Descargando {title!r} desde {indexer}."
@@ -399,7 +427,7 @@ WEBHOOK_HANDLERS = {
 }
 
 
-# ── Flask routes ──────────────────────────────────────────────────────────────
+# ── Flask routes ─────────────────────────────────────────────────────────────
 @app.route('/', methods=['POST'])
 def webhook():
     data = flask_request.json
@@ -413,7 +441,9 @@ def webhook():
         return handler(data, log)
 
     log.error(f"Tipo de evento desconocido: {event_type!r}")
-    return jsonify({"status": "error", "message": "Tipo de evento desconocido."}), 400
+    return jsonify(
+        {"status": "error", "message": "Tipo de evento desconocido."}
+    ), 400
 
 
 @app.route('/status', methods=['GET'])


### PR DESCRIPTION
## Description

Fixes the Docker network configuration for the deployed `straperr` container (it was joining a leftover dedicated network instead of the shared one), unblocks Dependabot version-bump PRs from ever triggering a release/deploy, cleans up flake8 line-length violations in `src/main.py`, and brings the affected docs and PR template in line with these changes.

## Type of change

Please mark the relevant options. These match the [Conventional Commits](../blob/main/docs/STYLEGUIDE.md#conventional-commits) types enforced on the PR title:

- [ ] `feat`: New feature (non-breaking change that adds functionality)
- [x] `fix`: Bug fix (non-breaking change that fixes an issue)
- [x] `docs`: Documentation-only change
- [x] `style`: Formatting/lint change with no logic change
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [ ] `ci`: Changes to CI/CD configuration or workflows
- [ ] `chore`: Maintenance tasks (e.g. dependency updates)
- [ ] `build`: Changes to the build system or dependencies
- [ ] Breaking change (any of the above that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](../blob/main/CONTRIBUTING.md) guidelines
- [x] The code follows the project's coding standards and best practices (see [**STYLEGUIDE**](../blob/main/docs/STYLEGUIDE.md))
- [ ] I have commented my code, particularly in hard-to-understand areas *(no logic complex enough to warrant new comments)*
- [x] I have updated the [**README**](../blob/main/README.md) or documentation, if necessary
- [ ] I have added relevant tests that prove my fix is effective or that my feature works *(these are workflow/config fixes with no unit-testable behavior; see note below)*
- [x] All new and existing tests pass with my changes
- [x] Any dependent changes have been merged and published in downstream modules *(none — no dependent changes)*

## Screenshots (if applicable)

N/A — no visual changes.

## Additional Notes

- **Action required before merging**: set the `DOCKER_NETWORK` repository variable to the name of the existing shared Docker network.
- `flake8 src/ tests/` passes with 0 errors after this PR.
- This repo's `pytest` step currently only runs files matching `tests/test_*.py` that aren't `tests/test_local_*.py`; every existing test file is `test_local_*.py` and is skipped in CI by design (they need local resources), so "tests pass" here refers to flake8, the only check that actually executes.
