### PR TITLE
fix(ci): forward deploy secrets and allow targeting a specific tag

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -97,6 +97,8 @@ jobs:
     needs: [setup, tests, scan, push, release]
     if: needs.setup.outputs.tag_version != ''
     uses: francisjgarcia/actions-templates/.github/workflows/wf-deploy.yml@main
+    secrets:
+      APP_ENV_SECRETS: ${{ secrets.APP_ENV_SECRETS }}
     with:
       tag_version: ${{ needs.setup.outputs.tag_version }}
       github_repository: ${{ github.repository }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,11 @@ name: Deploy application to server
 
 on:
   workflow_dispatch:
+    inputs:
+      tag_version:
+        description: "Tag to deploy (e.g. v1.0.0)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -19,24 +24,19 @@ defaults:
     working-directory: .
 
 jobs:
-  setup:
-    name: Setup environment
-    uses: francisjgarcia/actions-templates/.github/workflows/wf-setup.yml@main
-
   deploy:
     name: Deploy to server
-    needs: [setup]
     uses: francisjgarcia/actions-templates/.github/workflows/wf-deploy.yml@main
     secrets:
       APP_ENV_SECRETS: ${{ secrets.APP_ENV_SECRETS }}
     with:
-      tag_version: ${{ needs.setup.outputs.tag_version }}
+      tag_version: ${{ inputs.tag_version }}
       github_repository: ${{ github.repository }}
       containers: |
         [
           {
             "name": "straperr",
-            "image": "ghcr.io/${{ github.repository }}:${{ needs.setup.outputs.tag_version }}",
+            "image": "ghcr.io/${{ github.repository }}:${{ inputs.tag_version }}",
             "healthcheck_url": "${{ vars.DOCKER_HEALTHCHECK_URL }}",
             "memory_limit": "${{ vars.DOCKER_MEMORY_LIMIT }}",
             "memory_reservation": "${{ vars.DOCKER_MEMORY_RESERVATION }}",

--- a/README.md
+++ b/README.md
@@ -207,10 +207,9 @@ This repository includes a fully automated CI/CD pipeline using `cicd.yml` GitHu
 
 ### Deploy to server
 
-To deploy an specific version of the application to a remote server. You can use the `deploy.yml` workflow. This workflow is triggered by a manual event. Only the `main` branch and tags are allowed to trigger this workflow.
+To deploy a specific version of the application to a remote server, use the `deploy.yml` workflow. This workflow is triggered manually and requires a `tag_version` input (e.g. `v1.22.0`, or `latest`) naming an image tag already published to the GitHub Container Registry.
 
-1. **Setup**: Generates the necessary variables for use in the subsequent tasks.
-2. **Deploy**: Deploys the application to remote servers using SSH.
+1. **Deploy**: Deploys the given tag to remote servers using SSH.
 
 ### Remove deploy from server
 


### PR DESCRIPTION
## Description

Two related problems with the deployment workflows:

1. `cicd.yml`'s automatic `deploy` job (runs on push to `main`) never forwarded the `APP_ENV_SECRETS` secret to `wf-deploy.yml`, unlike the manual `deploy.yml` workflow. Repo variables (`vars.*`) reached the container, but secret-backed env vars (e.g. `HDOLIMPO_USERNAME`/`PASSWORD`, API keys) did not.
2. `deploy.yml` (manual redeploy/rollback workflow) called `wf-setup.yml` to compute a *new* version bump from commits since the last tag. When `main` had no qualifying commits since the last release, `bump_type` was `none`, `tag_version` came back empty, and the `deploy` job was skipped entirely (`no release (none commit)`) — making the workflow unusable for redeploying or rolling back to an already-published tag.

## Changes

- `cicd.yml`: pass `secrets: APP_ENV_SECRETS` to the `deploy` job, matching `deploy.yml`.
- `deploy.yml`: drop the `setup`/`wf-setup.yml` job and replace the computed `tag_version` with a required `workflow_dispatch` input, so any existing image tag in GHCR (including `latest`, confirmed present in the registry) can be deployed on demand.
- `README.md`: update the "Deploy to server" section to match (no more "Setup" step, mentions the `tag_version` input).

## Type of change

- [ ] `feat`: New feature (non-breaking change that adds functionality)
- [x] `fix`: Bug fix (non-breaking change that fixes an issue)
- [x] `docs`: Documentation-only change
- [ ] `style`: Formatting/lint change with no logic change
- [ ] `refactor`: Code change that neither fixes a bug nor adds a feature
- [ ] `perf`: Performance improvement
- [ ] `test`: Adding or updating tests
- [x] `ci`: Changes to CI/CD configuration or workflows
- [ ] `chore`: Maintenance tasks (e.g. dependency updates)
- [ ] `build`: Changes to the build system or dependencies
- [ ] Breaking change (any of the above that would cause existing functionality to not work as expected)
- [ ] Other (please describe):

## Checklist

- [x] I have read the [**CONTRIBUTING**](../blob/main/CONTRIBUTING.md) guidelines
- [x] The code follows the project's coding standards and best practices (see [**STYLEGUIDE**](../blob/main/docs/STYLEGUIDE.md))
- [ ] I have commented my code, particularly in hard-to-understand areas — not applicable, plain workflow config change with no non-obvious logic
- [x] I have updated the [**README**](../blob/main/README.md) or documentation, if necessary
- [ ] I have added relevant tests that prove my fix is effective or that my feature works — not applicable, no test suite covers GitHub Actions workflow files in this repo
- [ ] All new and existing tests pass with my changes — no Python code changed, so `flake8`/`pytest` are unaffected; the workflow logic itself can only be exercised by GitHub Actions once merged (see Additional Notes)
- [x] Any dependent changes have been merged and published in downstream modules — `wf-deploy.yml` already accepts `APP_ENV_SECRETS` and `tag_version`, no changes needed in `actions-templates`

## Additional Notes

- Merging this to `main` is itself a `fix(ci)` commit, so it will trigger a real patch release + deploy through `cicd.yml` — that run will be the first real-world check that `APP_ENV_SECRETS` now reaches the container.
- Before/after that deploy, worth confirming the `APP_ENV_SECRETS` secret is actually populated in the repo settings (Settings → Secrets and variables → Actions) — this PR only fixes the plumbing, it can't fix a secret that was never set.
- Once merged, `deploy.yml` can be run manually via `gh workflow run deploy.yml -f tag_version=v1.22.0` (or through the Actions UI) to redeploy/rollback to any published tag, including `latest`.