### PR TITLE
fix(hdolimpo): retry torrent search on stale element reference

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,7 @@ import logging
 import requests
 from flask import Flask, request as flask_request, jsonify
 from selenium import webdriver
+from selenium.common.exceptions import StaleElementReferenceException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.chrome.service import Service
@@ -285,24 +286,39 @@ def hdolimpo_thanks(
             log.error(f"Error buscando el título: {e}")
             return False
 
-        try:
-            torrent_list = driver.find_element(By.ID, "torrent-list-table")
-            result_links = torrent_list.find_elements(
-                By.XPATH, ".//tbody/tr/td/a"
-            )
+        # La tabla de resultados se re-renderiza vía JS (búsqueda en vivo)
+        # tras cada tecleo, por lo que los elementos pueden quedar stale
+        # mientras los leemos; reintentamos releyendo la tabla desde cero.
+        result_url = None
+        max_attempts = 3
+        for attempt in range(1, max_attempts + 1):
+            try:
+                torrent_list = driver.find_element(By.ID, "torrent-list-table")
+                result_links = torrent_list.find_elements(
+                    By.XPATH, ".//tbody/tr/td/a"
+                )
 
-            result_url = None
-            for link in result_links:
-                if link.text == search_query:
-                    result_url = link.get_attribute("href")
-                    log.info(f"Torrent encontrado: {result_url}")
-                    break
-
-            if not result_url:
-                log.warning(f"Sin coincidencia exacta para {search_query!r}.")
+                for link in result_links:
+                    if link.text == search_query:
+                        result_url = link.get_attribute("href")
+                        log.info(f"Torrent encontrado: {result_url}")
+                        break
+                break
+            except StaleElementReferenceException:
+                if attempt == max_attempts:
+                    log.error(
+                        "Error obteniendo el resultado de búsqueda: "
+                        "la tabla de resultados no se estabilizó "
+                        f"tras {max_attempts} intentos."
+                    )
+                    return False
+                time.sleep(1)
+            except Exception as e:
+                log.error(f"Error obteniendo el resultado de búsqueda: {e}")
                 return False
-        except Exception as e:
-            log.error(f"Error obteniendo el resultado de búsqueda: {e}")
+
+        if not result_url:
+            log.warning(f"Sin coincidencia exacta para {search_query!r}.")
             return False
 
         # ── 3. Página del torrent → clic en Agradecer ────────────────────────


### PR DESCRIPTION
## Description

`hdolimpo_thanks()` was intermittently failing with `StaleElementReferenceException` while reading the torrent search results table, even though it had worked moments earlier in the same run. The results table on hd-olimpo.club re-renders via JS (live search-as-you-type), so the previously located `#torrent-list-table` element / its child links can be swapped out by the page between the `find_element` call and the loop reading `link.text`, depending on render timing.

This adds a bounded retry (3 attempts, re-querying the table from scratch, 1s backoff) around that read so a transient re-render doesn't abort the whole Grab-thanks flow.

## Type of change

- [x] `fix`: Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have read the CONTRIBUTING guidelines
- [x] The code follows the project's coding standards and best practices (flake8 --max-line-length=100 passes)
- [ ] I have commented my code, particularly in hard-to-understand areas — added one comment explaining the retry rationale; no further commenting needed
- [ ] I have updated the README or documentation, if necessary — not applicable, no docs reference this internal retry behavior
- [ ] I have added relevant tests that prove my fix is effective or that my feature works — the `tests/` scripts in this repo are manual smoke scripts against a live HD-Olimpo login, not automated coverage of this code path; no existing automated test harness to extend
- [ ] All new and existing tests pass with my changes — there is no pytest-collected test suite to run (see AGENTS.md); verified via `flake8` and `ast.parse` only
- [ ] Any dependent changes have been merged and published in downstream modules — not applicable

## Additional Notes

This was triggered by intermittent production failures reported by the user (Radarr 4K / Prowlarr grabs hitting `stale element reference` on `torrent-list-table`) after previously working fine — consistent with a race against the site's live-search re-render rather than a logic bug. Not verified against the live site in this session (no local container running); the fix should be validated against a real Grab event after deploy.